### PR TITLE
Update auth method for Azure Maps

### DIFF
--- a/Common/WebAPISkillHelper.cs
+++ b/Common/WebAPISkillHelper.cs
@@ -70,10 +70,19 @@ namespace AzureCognitiveSearch.PowerSkills.Common
             return response;
         }
 
+        public static async Task<IEnumerable<T>> FetchAsync<T>(string uri, string collectionPath)
+            => await FetchAsync<T>(uri, null, null, collectionPath, HttpMethod.Get);
+
         public static async Task<IEnumerable<T>> FetchAsync<T>(string uri, string apiKeyHeader, string apiKey, string collectionPath)
-        {
-            return await FetchAsync<T>(uri, apiKeyHeader, apiKey, collectionPath, HttpMethod.Get);
-        }
+            => await FetchAsync<T>(uri, apiKeyHeader, apiKey, collectionPath, HttpMethod.Get);
+
+        public static async Task<IEnumerable<T>> FetchAsync<T>(
+            string uri,
+            string collectionPath,
+            HttpMethod method,
+            byte[] postBody = null,
+            string contentType = null)
+            => await FetchAsync<T>(uri, null, null, collectionPath, method, postBody, contentType);
 
         public static async Task<IEnumerable<T>> FetchAsync<T>(
             string uri,
@@ -97,7 +106,10 @@ namespace AzureCognitiveSearch.PowerSkills.Common
                 {
                     request.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
                 }
-                request.Headers.Add(apiKeyHeader, apiKey);
+                if (apiKeyHeader != null)
+                {
+                    request.Headers.Add(apiKeyHeader, apiKey);
+                }
 
                 using (HttpResponseMessage response = TestMode ? TestWww(request) : await client.SendAsync(request))
                 {
@@ -120,6 +132,5 @@ namespace AzureCognitiveSearch.PowerSkills.Common
                 }
             }
         }
-
     }
 }

--- a/Geo/GeoPointFromName/GeoPointFromName.cs
+++ b/Geo/GeoPointFromName/GeoPointFromName.cs
@@ -39,10 +39,12 @@ namespace AzureCognitiveSearch.PowerSkills.Geo.GeoPointFromName
             WebApiSkillResponse response = await WebApiSkillHelpers.ProcessRequestRecordsAsync(skillName, requestRecords,
                 async (inRecord, outRecord) => {
                     var address = inRecord.Data["address"] as string;
-                    string uri = azureMapsUri + "?api-version=1.0&query=" + Uri.EscapeDataString(address);
+                    string uri = azureMapsUri
+                        + "?api-version=1.0&query=" + Uri.EscapeDataString(address)
+                        + "&subscription-key=" + Uri.EscapeDataString(azureMapsKey);
 
                     IEnumerable<Geography> geographies =
-                        await WebApiSkillHelpers.FetchAsync<Geography>(uri, "X-ms-client-id", azureMapsKey, "results");
+                        await WebApiSkillHelpers.FetchAsync<Geography>(uri, "results");
 
                     if (geographies.FirstOrDefault() is Geography mainGeoPoint)
                     {

--- a/Text/BingEntitySearch/BingEntitySearch.cs
+++ b/Text/BingEntitySearch/BingEntitySearch.cs
@@ -41,7 +41,9 @@ namespace AzureCognitiveSearch.PowerSkills.Text.BingEntitySearch
             WebApiSkillResponse response = await WebApiSkillHelpers.ProcessRequestRecordsAsync(skillName, requestRecords,
                 async (inRecord, outRecord) => {
                     var entityName = inRecord.Data["name"] as string;
-                    string uri = bingApiEndpoint + "?q=" + Uri.EscapeDataString(entityName) + "&mkt=en-us&count=10&offset=0&safesearch=Moderate";
+                    string uri = bingApiEndpoint
+                        + "?q=" + Uri.EscapeDataString(entityName)
+                        + "&mkt=en-us&safeSearch=Moderate";
 
                     IEnumerable<BingEntity> entities =
                         await WebApiSkillHelpers.FetchAsync<BingEntity>(uri, "Ocp-Apim-Subscription-Key", bingApiKey, "entities.value");


### PR DESCRIPTION
This service used to work with the API key passed in as a header, but now require it to be passed as a query string parameter.