### PR TITLE
Fixed vision/AnalyzeForm GetFields and JSON struct

### DIFF
--- a/Vision/AnalyzeForm/AnalyzeForm.cs
+++ b/Vision/AnalyzeForm/AnalyzeForm.cs
@@ -107,10 +107,23 @@ namespace AzureCognitiveSearch.PowerSkills.Vision.AnalyzeForm
         /// <returns></returns>
         private static string GetField(IList<Page> pages, string fieldName)
         {
-            IEnumerable<string> value = pages
-                .SelectMany(p => p.KeyValuePairs)
-                .Where(kvp => string.Equals(kvp.Key.Text.Trim(), fieldName, StringComparison.CurrentCultureIgnoreCase))
-                .Select(kvp => kvp.Value.Text);
+            List<string> textValues = (from p in pages from t in p.tables from c in t.cells select c.Text).ToList();
+            int idx = textValues.FindIndex(i => string.Equals( i.Trim(), fieldName, StringComparison.CurrentCultureIgnoreCase));
+
+            string value;
+            if (idx + 1 > textValues.Count || idx == -1)
+                value = null;
+            else
+                value = textValues[idx + 1];
+
+            //textValues.Select((v, i) => new { value = v, index = i }).Where( string.Equals( item, fieldName, StringComparison.CurrentCultureIgnoreCase))
+            //string.Equals(item, "sdasdsad", StringComparison.CurrentCultureIgnoreCase)
+            //string value = textValues.SkipWhile(item => string.Equals(item, fieldName, StringComparison.CurrentCultureIgnoreCase)).FirstOrDefault();
+
+            /*IEnumerable<string> value1 = pages
+                .SelectMany(p => p.tables)
+                .Where(t => string.Equals(t.cells[0].Text.Trim(), fieldName, StringComparison.CurrentCultureIgnoreCase))
+                .Select(t => t.cells[0].Text);*/
             return value == null ? null : string.Join(" ", value);
         }
 
@@ -122,7 +135,7 @@ namespace AzureCognitiveSearch.PowerSkills.Vision.AnalyzeForm
         /// <returns>The job id that can be used in analyzeResults.</returns>
         private static async Task<string> GetJobId(string endpointUrl, string formUrl, string modelId, string apiKey)
         {
-            string uri = endpointUrl + "/formrecognizer/v2.0-preview/custom/models/" + Uri.EscapeDataString(modelId) + "/analyze";
+            string uri = endpointUrl + "/formrecognizer/v2.1-preview.2/custom/models/" + Uri.EscapeDataString(modelId) + "/analyze";
 
             using (var client = new HttpClient())
             {

--- a/Vision/AnalyzeForm/AnalyzeForm.csproj
+++ b/Vision/AnalyzeForm/AnalyzeForm.csproj
@@ -13,8 +13,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Vision/AnalyzeForm/Cell.cs
+++ b/Vision/AnalyzeForm/Cell.cs
@@ -3,10 +3,12 @@
 
 namespace AzureCognitiveSearch.PowerSkills.Vision.AnalyzeForm
 {
-    public class BoundedElement
+    public class Cell
     {
         public string Text { get; set; }
         public double[] BoundingBox { get; set; }
-        public string[] Elements { get; set; }
+        public int columnIndex { get; set; }
+        public int rowIndex { get; set; }
+        public int rowSpan { get; set; }
     }
 }

--- a/Vision/AnalyzeForm/Page.cs
+++ b/Vision/AnalyzeForm/Page.cs
@@ -8,9 +8,9 @@ namespace AzureCognitiveSearch.PowerSkills.Vision.AnalyzeForm
     public class Page
     {
         [JsonProperty(PropertyName ="page")]
-        public int Number { get; set; }
-        public int? ClusterId { get; set; }
+        public int page { get; set; }
+        //public int? ClusterId { get; set; }
 
-        public KeyValuePair[] KeyValuePairs { get; set; }
+        public Table[] tables { get; set; }
     }
 }

--- a/Vision/AnalyzeForm/Table.cs
+++ b/Vision/AnalyzeForm/Table.cs
@@ -3,10 +3,11 @@
 
 namespace AzureCognitiveSearch.PowerSkills.Vision.AnalyzeForm
 {
-    public class KeyValuePair
+    public class Table
     {
-        public BoundedElement Key { get; set; }
-        public BoundedElement Value { get; set; }
-        public double Confidence { get; set; }
+        public double[] boundingBox { get; set; }
+        public int columns { get; set; }
+        public int rows { get; set; }
+        public Cell[] cells { get; set; }
     }
 }

--- a/Vision/AnalyzeForm/field-mappings.json
+++ b/Vision/AnalyzeForm/field-mappings.json
@@ -1,4 +1,11 @@
 {
-  "Address:": "address",
-  "Invoice For:": "recipient"
+  "Name:": "Name",
+  "Address:": "Address",
+  "City:": "City",
+  "Postal Code:": "PostalCode",
+  "Country:": "Country",
+  "Date of Birth:": "DOB",
+  "Destination:": "DestinationCity",
+  "Departure Date:": "DepartureDate",
+  "Return Date:": "ReturnDate"
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
The Vision/AnalyzeForm sample uses an outdated version of the form recogniser API which results in "unreferenced objects" exception errors in the GetFields function.
This has been raised in https://github.com/Azure-Samples/azure-search-power-skills/issues/31 back in July 2020.
The data model classes used do not reflect the actual API.

I've updated the data model and updated the LINQ (very simplistic) to point to new from recognizer API.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[❌ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[❌] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
Follow instructions per documentation: https://docs.microsoft.com/en-us/azure/search/cognitive-search-custom-skill-form
```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...


## Other Information
<!-- Add any other helpful information that may be needed here. -->