### PR TITLE
Bug due to compatibility issues with tensorflow and keras

### DIFF
--- a/Vision/ImageSimilarity/powerskill/extractor.py
+++ b/Vision/ImageSimilarity/powerskill/extractor.py
@@ -7,9 +7,9 @@ from heapq import nsmallest
 import numpy as np
 from PIL import Image
 from dotenv import load_dotenv
-from keras.applications.resnet50 import preprocess_input
-from keras.models import Model
-from keras.preprocessing import image
+from tensorflow.keras.applications.resnet50 import preprocess_input
+from tensorflow.keras.models import Model
+from tensorflow.keras.preprocessing import image
 from objdict import ObjDict
 from powerskill.timer import timefunc
 from scipy.spatial import distance

--- a/Vision/ImageSimilarity/powerskill/models.py
+++ b/Vision/ImageSimilarity/powerskill/models.py
@@ -1,7 +1,7 @@
 import os
 
 import joblib
-from keras.applications.resnet50 import ResNet50
+from tensorflow.keras.applications.resnet50 import ResNet50
 
 
 class Models:


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* I wasn't able to do docker run .. on imageSimilarity powerskill before and it was giving me the error "AttributeError: module 'tensorflow.python.keras.utils.generic_utils' has no attribute 'populate_dict_with_module_objects'. Believe this is due to incompatibility between current version of tensorflow and keras. This can be fixed by changing all import keras.xxx to import tensorflow.keras.xxx. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/neharanadee/azure-search-power-skills.git
git checkout fix_bug_in_imageSimilarity 
Run the imageSimilarity docker image (as usual follow the steps provided in the readme)
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check 
* The docker image for imageSimilarity powerskill should run after these changes.

## Other Information
<!-- Add any other helpful information that may be needed here. -->