### PR TITLE
Consolidate chat completion custom skill code for Open-AI and non OpenAI language models

### DIFF
--- a/ChatCompletionCustomSkill/README.md
+++ b/ChatCompletionCustomSkill/README.md
@@ -4,7 +4,7 @@
 
 Quickstart Guide:
 
-- This folder illustrates how to leverage Azure AI Studio to summarize a large piece of text using [custom web api skills](https://learn.microsoft.com/en-us/azure/search/cognitive-search-custom-skill-web-api).
+- This folder illustrates how to leverage Azure AI Studio with a deployed language model of your choice to do a chat-completion skill using [custom web api skills](https://learn.microsoft.com/en-us/azure/search/cognitive-search-custom-skill-web-api).
 
 - As a prerequisite to running this custom skill, you must first deploy a model to Azure. See [this guide](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-openai) for reference.
 

--- a/ChatCompletionCustomSkill/README.md
+++ b/ChatCompletionCustomSkill/README.md
@@ -1,10 +1,10 @@
-# Azure Studio Chat Completion Custom Skill for User-Chosen Language Models
+# Azure AI Foundry Chat Completion Custom Skill for User-Chosen Language Models
 
 ---
 
 Quickstart Guide:
 
-- This folder illustrates how to leverage Azure AI Studio with a deployed language model of your choice to do a chat-completion skill using [custom web api skills](https://learn.microsoft.com/en-us/azure/search/cognitive-search-custom-skill-web-api).
+- This folder illustrates how to leverage Azure AI Foundry with a deployed language model of your choice to do a chat-completion skill using [custom web api skills](https://learn.microsoft.com/en-us/azure/search/cognitive-search-custom-skill-web-api).
 
 - As a prerequisite to running this custom skill, you must first deploy a model to Azure. See [this guide](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/deploy-models-openai) for reference.
 

--- a/ChatCompletionCustomSkill/function_app.py
+++ b/ChatCompletionCustomSkill/function_app.py
@@ -139,7 +139,15 @@ def prepare_messages(request_body: Dict[str, Any], scenario: str,
                 raise CustomSkillException("Invalid base64 encoding", 400)
                 
             image_base64encoded = f"data:{image_type};base64,{image_data}"
-            system_message = SystemMessage(content=custom_prompts.get("image-captioning-default-system-prompt"))
+            system_message = {
+            "role": "system",
+            "content": [
+                    {
+                        "type": "text",
+                        "text": custom_prompts.get("image-captioning-default-system-prompt")
+                    }
+                ]
+            }
             return [
                 system_message,
                 {

--- a/ChatCompletionCustomSkill/function_app.py
+++ b/ChatCompletionCustomSkill/function_app.py
@@ -246,18 +246,25 @@ async def custom_skill(req: func.HttpRequest) -> func.HttpResponse:
 
                     # print(f'request_payload: {request_payload}')
                     print(f'The headers are : {headers}')
-                    vanilla_response = requests.post(endpoint, headers=headers, json=request_payload)
-                    print(f'the vanilla response is : {vanilla_response}')
-                    vanilla_response.raise_for_status()  # Will raise an HTTPError if the HTTP request returned an unsuccessful status code
-                    vanilla_response_json = vanilla_response.json()
+                    # vanilla_response = requests.post(endpoint, headers=headers, json=request_payload)
+                    # print(f'the vanilla response is : {vanilla_response}')
+                    # vanilla_response.raise_for_status()  # Will raise an HTTPError if the HTTP request returned an unsuccessful status code
+                    # vanilla_response_json = vanilla_response.json()
                     # TODO: this WORKED! Now I just need to massage this requests.post() response into the same format as the ChatCompletionsClient response
-                    print(f'vanilla_response_json: {vanilla_response_json}')
+                    
                     
                     # Call model with timeout
                     async with asyncio.timeout(config.timeout):
                         # just use requests.post() here instead
-                        response = await client.complete(request_payload)
-                        response_text = response.choices[0].message.content
+                        # response = await client.complete(request_payload)
+                        # response_text = response.choices[0].message.content
+
+                        vanilla_response = requests.post(endpoint, headers=headers, json=request_payload)
+                        # print(f'the vanilla response is : {vanilla_response}')
+                        vanilla_response.raise_for_status()  # Will raise an HTTPError if the HTTP request returned an unsuccessful status code
+                        vanilla_response_json = vanilla_response.json()
+                        print(f'vanilla_response_json: {vanilla_response_json}')
+                        response_text = vanilla_response_json['choices'][0]['message']['content']
                         
                     # Format response
                     response_values.append(format_response(request_body, response_text, scenario))

--- a/ChatCompletionCustomSkill/function_app.py
+++ b/ChatCompletionCustomSkill/function_app.py
@@ -11,10 +11,6 @@ from enum import Enum
 import base64
 import time
 import requests
-from azure.ai.inference.models import (
-        SystemMessage,
-        UserMessage,
-    )
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -49,24 +45,6 @@ def load_custom_prompts() -> Dict[str, str]:
         logger.error(f"Failed to load custom prompts: {e}")
         raise CustomSkillException("Failed to load custom prompts", 500)
 
-async def create_chat_client() -> ChatCompletionsClient:
-    """Create and configure chat client"""
-    try:
-        api_key = os.getenv("AZURE_INFERENCE_CREDENTIAL")
-        endpoint = os.getenv("AZURE_CHAT_COMPLETION_ENDPOINT")
-        
-        if not api_key or not endpoint:
-            raise CustomSkillException("Missing required environment variables", 500)
-            
-        print(f"Creating chat client with endpoint: {endpoint} and api_key: {api_key}")
-        return ChatCompletionsClient(
-            endpoint=endpoint,
-            credential=AzureKeyCredential(api_key)
-        )
-    except Exception as e:
-        logger.error(f"Failed to create chat client: {e}")
-        raise CustomSkillException("Failed to initialize chat client", 500)
-
 def prepare_messages(request_body: Dict[str, Any], scenario: str, 
                     custom_prompts: Dict[str, str]) -> List[Dict[str, Any]]:
     """Prepare messages based on scenario"""
@@ -99,7 +77,6 @@ def prepare_messages(request_body: Dict[str, Any], scenario: str,
             text = request_body.get("data", {}).get("text", "")
             if not text:
                 raise CustomSkillException("Missing text for entity recognition", 400)
-            # system_message = SystemMessage(content=custom_prompts.get("entity-recognition-default-system-prompt"))
             system_message = {
             "role": "system",
             "content": [
@@ -109,7 +86,6 @@ def prepare_messages(request_body: Dict[str, Any], scenario: str,
                     }
                 ]
             }
-            # user_message = UserMessage(content=text)
             user_message = {
             "role": "user",
             "content": [
@@ -206,24 +182,8 @@ def format_response(request_body: Dict[str, Any], response_text: str,
 @app.route(route="health", auth_level=func.AuthLevel.ANONYMOUS)
 async def health_check(req: func.HttpRequest) -> func.HttpResponse:
     """Health check endpoint"""
-    try:
-        custom_prompts = load_custom_prompts()
-        async with await create_chat_client() as client:
-            response_body = {
-                "status": "Healthy",
-                "timestamp": time.time(),
-                "checks": {
-                    "prompts": "OK",
-                    "client": "OK"
-                }
-            }
-            return func.HttpResponse(json.dumps(response_body), mimetype="application/json")
-    except Exception as e:
-        return func.HttpResponse(
-            json.dumps({"status": "Unhealthy", "error": str(e)}),
-            mimetype="application/json",
-            status_code=500
-        )
+    response_body = {"status": "Healthy"}
+    return func.HttpResponse(json.dumps(response_body), mimetype="application/json")
 
 @app.function_name(name="AIStudioModelCatalogSkill")
 @app.route(route="custom_skill", auth_level=func.AuthLevel.ANONYMOUS)
@@ -254,44 +214,40 @@ async def custom_skill(req: func.HttpRequest) -> func.HttpResponse:
         "api-key": api_key,
         "Authorization": f"Bearer {api_key}"
         }
-        # TODO: we no longer need to create this chat client
-        async with await create_chat_client() as client:
-            for request_body in input_values:
-                try:
-                    messages = prepare_messages(request_body, scenario, custom_prompts)
-                    request_payload = {
-                        "messages": messages,
-                        "temperature": config.temperature,
-                        "top_p": config.top_p,
-                        "max_tokens": config.max_tokens
-                    }
-                    print(f'The headers are : {headers}')
-                    # Call model with timeout
-                    async with asyncio.timeout(config.timeout):
-                        vanilla_response = requests.post(endpoint, headers=headers, json=request_payload)
-                        vanilla_response.raise_for_status()  # Will raise an HTTPError if the HTTP request returned an unsuccessful status code
-                        vanilla_response_json = vanilla_response.json()
-                        print(f'vanilla_response_json: {vanilla_response_json}')
-                        response_text = vanilla_response_json['choices'][0]['message']['content']
-                    # Format response
-                    response_values.append(format_response(request_body, response_text, scenario))
-                    
-                except asyncio.TimeoutError:
-                    logger.error(f"Timeout processing record {request_body.get('recordId')}")
-                    response_values.append({
-                        "recordId": request_body.get("recordId"),
-                        "errors": ["Request timeout"],
-                        "warnings": None,
-                        "data": None
-                    })
-                except Exception as e:
-                    logger.error(f"Error processing record {request_body.get('recordId')}: {e}")
-                    response_values.append({
-                        "recordId": request_body.get("recordId"),
-                        "errors": [str(e)],
-                        "warnings": None,
-                        "data": None
-                    })
+        for request_body in input_values:
+            try:
+                messages = prepare_messages(request_body, scenario, custom_prompts)
+                request_payload = {
+                    "messages": messages,
+                    "temperature": config.temperature,
+                    "top_p": config.top_p,
+                    "max_tokens": config.max_tokens
+                }
+                # Call model with timeout
+                async with asyncio.timeout(config.timeout):
+                    vanilla_response = requests.post(endpoint, headers=headers, json=request_payload)
+                    vanilla_response.raise_for_status()  # Will raise an HTTPError if the HTTP request returned an unsuccessful status code
+                    vanilla_response_json = vanilla_response.json()
+                    response_text = vanilla_response_json['choices'][0]['message']['content']
+                # Format response
+                response_values.append(format_response(request_body, response_text, scenario))
+                
+            except asyncio.TimeoutError:
+                logger.error(f"Timeout processing record {request_body.get('recordId')}")
+                response_values.append({
+                    "recordId": request_body.get("recordId"),
+                    "errors": ["Request timeout"],
+                    "warnings": None,
+                    "data": None
+                })
+            except Exception as e:
+                logger.error(f"Error processing record {request_body.get('recordId')}: {e}")
+                response_values.append({
+                    "recordId": request_body.get("recordId"),
+                    "errors": [str(e)],
+                    "warnings": None,
+                    "data": None
+                })
 
         # Log processing time
         processing_time = time.time() - start_time

--- a/ChatCompletionCustomSkill/function_app.py
+++ b/ChatCompletionCustomSkill/function_app.py
@@ -75,7 +75,6 @@ def prepare_messages(request_body: Dict[str, Any], scenario: str,
             text = request_body.get("data", {}).get("text", "")
             if not text:
                 raise CustomSkillException("Missing text for summarization", 400)
-            # system_message = SystemMessage(content=custom_prompts.get("summarize-default-system-prompt"))
             system_message = {
             "role": "system",
             "content": [
@@ -85,7 +84,6 @@ def prepare_messages(request_body: Dict[str, Any], scenario: str,
                     }
                 ]
             }
-            # user_message = UserMessage(content=text)
             user_message = {
             "role": "user",
             "content": [
@@ -101,8 +99,26 @@ def prepare_messages(request_body: Dict[str, Any], scenario: str,
             text = request_body.get("data", {}).get("text", "")
             if not text:
                 raise CustomSkillException("Missing text for entity recognition", 400)
-            system_message = SystemMessage(content=custom_prompts.get("entity-recognition-default-system-prompt"))
-            user_message = UserMessage(content=text)
+            # system_message = SystemMessage(content=custom_prompts.get("entity-recognition-default-system-prompt"))
+            system_message = {
+            "role": "system",
+            "content": [
+                    {
+                        "type": "text",
+                        "text": custom_prompts.get("entity-recognition-default-system-prompt")
+                    }
+                ]
+            }
+            # user_message = UserMessage(content=text)
+            user_message = {
+            "role": "user",
+            "content": [
+                    {
+                    "type": "text",
+                    "text": text
+                    }
+                ]
+            }
             return [ system_message, user_message ]
             
         elif scenario == ScenarioType.IMAGE_CAPTIONING.value:

--- a/ChatCompletionCustomSkill/function_app.py
+++ b/ChatCompletionCustomSkill/function_app.py
@@ -230,42 +230,25 @@ async def custom_skill(req: func.HttpRequest) -> func.HttpResponse:
         "api-key": api_key,
         "Authorization": f"Bearer {api_key}"
         }
+        # TODO: we no longer need to create this chat client
         async with await create_chat_client() as client:
             for request_body in input_values:
                 try:
-                    # Prepare messages
                     messages = prepare_messages(request_body, scenario, custom_prompts)
-                    
-                    # Prepare request payload
                     request_payload = {
                         "messages": messages,
                         "temperature": config.temperature,
                         "top_p": config.top_p,
                         "max_tokens": config.max_tokens
                     }
-
-                    # print(f'request_payload: {request_payload}')
                     print(f'The headers are : {headers}')
-                    # vanilla_response = requests.post(endpoint, headers=headers, json=request_payload)
-                    # print(f'the vanilla response is : {vanilla_response}')
-                    # vanilla_response.raise_for_status()  # Will raise an HTTPError if the HTTP request returned an unsuccessful status code
-                    # vanilla_response_json = vanilla_response.json()
-                    # TODO: this WORKED! Now I just need to massage this requests.post() response into the same format as the ChatCompletionsClient response
-                    
-                    
                     # Call model with timeout
                     async with asyncio.timeout(config.timeout):
-                        # just use requests.post() here instead
-                        # response = await client.complete(request_payload)
-                        # response_text = response.choices[0].message.content
-
                         vanilla_response = requests.post(endpoint, headers=headers, json=request_payload)
-                        # print(f'the vanilla response is : {vanilla_response}')
                         vanilla_response.raise_for_status()  # Will raise an HTTPError if the HTTP request returned an unsuccessful status code
                         vanilla_response_json = vanilla_response.json()
                         print(f'vanilla_response_json: {vanilla_response_json}')
                         response_text = vanilla_response_json['choices'][0]['message']['content']
-                        
                     # Format response
                     response_values.append(format_response(request_body, response_text, scenario))
                     


### PR DESCRIPTION
Previously we drew a line for doing chat-completion inference tasks based on whether the language model was from OpenAI or different (llama, Phi, Cohere, etc.). I've now converged that code so that a user can use the exact same custom skill code to call whichever language model they prefer. All they have to do is modify their environment variables.

I tested this by running this code across text-summarization, entity recognition and image verbalization AND across different language model deployments (gpt-4o & phi 3-5)